### PR TITLE
Removed line about ECS CLI being moved to Blox github org

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,8 +120,7 @@
 						<p>The <a href="https://github.com/aws/amazon-ecs-cli">Amazon ECS Command Line Interface (CLI)</a> is a command line interface for Amazon ECS that provides
 						high-level commands to simplify creating, updating, and monitoring clusters and tasks from a local
 						development environment and deploying tasks to production on Amazon ECS. You can use the CLI, as an
-						alternative to the AWS Management Console, for everyday development and testing. Previously, the ECS
-						CLI was part of the AWS GitHub organization and has now moved under the Blox GitHub organization.</p>
+						alternative to the AWS Management Console, for everyday development and testing.</p>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
The ECS CLI is still currently under the AWS github org, so removing this line until it actually is moved into the Blox github org. 